### PR TITLE
Use #/usr/bin/env node as a hashbang

### DIFF
--- a/bin/ncp
+++ b/bin/ncp
@@ -1,4 +1,4 @@
-#!/usr/local/bin/node
+#!/usr/bin/env node
 
 
 


### PR DESCRIPTION
Using #/usr/local/bin/node makes things like nvm fail pretty hard. Also,
some people install in different locations.

Example (I've node installed in /usr/bin, but the point is very much the
same):

```
[maciej@PC03 ~]$ /usr/bin/env node --version
v0.5.7
[maciej@PC03 ~]$ nvm use v0.4.12
Now using node v0.4.12
[maciej@PC03 ~]$ /usr/bin/env node --version
v0.4.12
[maciej@PC03 ~]$ /usr/bin/node --version
v0.5.7
```
