### PR TITLE
Use path.resolve for cross platform support

### DIFF
--- a/lib/ncp.js
+++ b/lib/ncp.js
@@ -1,5 +1,4 @@
 
-
 var fs = require('fs'),
     path = require('path');
 
@@ -12,8 +11,8 @@ ncp.ncp = function (source, dest, options, callback) {
   }
 
   var basePath = process.cwd(),
-      currentPath = (source[0] === '/') ? source : basePath + '/' + source,
-      targetPath = (dest[0] === '/') ? dest : basePath + '/' + dest,
+      currentPath = path.resolve(basePath, source),
+      targetPath = path.resolve(basePath, des),
       filter = options.filter,
       errs = null,
       started = 0,


### PR DESCRIPTION
http://nodejs.org/docs/v0.6.4/api/path.html#path.resolve

This will make it work with windows. Needed to get jitsu running on 0.6.4 (windows 7)
