### PR TITLE
ReferenceError: des is not defined

### DIFF
--- a/lib/ncp.js
+++ b/lib/ncp.js
@@ -1,4 +1,3 @@
-
 var fs = require('fs'),
     path = require('path');
 
@@ -12,7 +11,7 @@ ncp.ncp = function (source, dest, options, callback) {
 
   var basePath = process.cwd(),
       currentPath = path.resolve(basePath, source),
-      targetPath = path.resolve(basePath, des),
+      targetPath = path.resolve(basePath, dest),
       filter = options.filter,
       errs = null,
       started = 0,


### PR DESCRIPTION
Fix a typo. Was getting this error "ReferenceError: des is not defined" on v0.2.3 published on npmjs.org .
