### PR TITLE
Callback is not called if some of the files were filtered out

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,4 @@
 # ncp - Asynchronous recursive file & directory copying
 
-[![Build Status](https://secure.travis-ci.org/AvianFlu/ncp.png)](http://travis-ci.org/AvianFlu/ncp)
-
-Think `cp -r`, but pure node, and asynchronous.  `ncp` can be used both as a CLI tool and programmatically.
-
-## Command Line usage
-
-Usage is simple: `ncp [source] [dest] [--limit=concurrency limit]
-[--filter=filter] --stopOnErr`
-
-The 'filter' is a Regular Expression - matched files will be copied.
-
-The 'concurrency limit' is an integer that represents how many pending file system requests `ncp` has at a time.
-
-'stopOnErr' is a boolean flag that will tell `ncp` to stop immediately if any
-errors arise, rather than attempting to continue while logging errors.
-
-If there are no errors, `ncp` will output `done.` when complete.  If there are errors, the error messages will be logged to `stdout` and to `./ncp-debug.log`, and the copy operation will attempt to continue.
-
-## Programmatic usage
-
-Programmatic usage of `ncp` is just as simple.  The only argument to the completion callback is a possible error.  
-
-```javascript
-var ncp = require('ncp').ncp;
-
-ncp.limit = 16;
-
-ncp(source, destination, function (err) {
- if (err) {
-   return console.error(err);
- }
- console.log('done!');
-});
-```
-
-You can also call ncp like `ncp(source, destination, options, callback)`. 
-`options` should be a dictionary. Currently, such options are available:
-
-  * `options.filter` - a `RegExp` instance, against which each file name is
-  tested to determine whether to copy it or not, or a function taking single
-  parameter: copied file name, returning `true` or `false`, determining
-  whether to copy file or not.
-
-Please open an issue if any bugs arise.  As always, I accept (working) pull requests, and refunds are available at `/dev/null`.
+This fork is made to resolve bug with filtering files. Most likely, you don't want to use this fork and its changes
+are already in main repo.

--- a/lib/ncp.js
+++ b/lib/ncp.js
@@ -28,12 +28,12 @@ ncp.ncp = function (source, dest, options, callback) {
     if (filter) {
       if (filter instanceof RegExp) {
         if (!filter.test(item)) {
-          return cb();
+          return cb(true);
         }
       }
       else if (typeof filter === 'function') {
         if (!filter(item)) {
-          return cb();
+          return cb(true);
         }
       }
     }
@@ -181,8 +181,8 @@ ncp.ncp = function (source, dest, options, callback) {
     return cb();
   }
 
-  function cb() {
-    running--;
+  function cb(notDecreaseRunning) {
+    if (!notDecreaseRunning) running--;
     finished++;
     if ((started === finished) && (running === 0)) {
       return errs ? callback(errs) : callback(null);

--- a/test/ncp-test.js
+++ b/test/ncp-test.js
@@ -35,5 +35,44 @@ vows.describe('ncp').addBatch({
       }
     }
   }
+}).addBatch({
+  'When using ncp': {
+    'and copying files using filter': {
+      topic: function() {
+        var cb = this.callback;
+        var filter = function(name) {
+          return name.substr(name.length - 1) != 'a'
+        }
+        rimraf(out, function () {
+          ncp(src, out, {filter: filter}, cb);
+        });
+      },
+      'it should copy files': {
+        topic: function () {
+          var cb = this.callback;
+
+          readDirFiles(src, 'utf8', function (srcErr, srcFiles) {
+            function filter(files) {
+              for (var fileName in files) {
+                var curFile = files[fileName];
+                if (curFile instanceof Object)
+                  return filter(curFile);
+                if (fileName == 'a')
+                  delete files[fileName];
+              }
+            }
+            filter(srcFiles);
+            readDirFiles(out, 'utf8', function (outErr, outFiles) {
+              cb(outErr, srcFiles, outFiles);
+            });
+          });
+        },
+        'and destination files should match source files that pass filter': function (err, srcFiles, outFiles) {
+          assert.isNull(err);
+          assert.deepEqual(srcFiles, outFiles);
+        }
+      }
+    }
+  }
 }).export(module);
 


### PR DESCRIPTION
I updated tests so you can try new tests with old code - it will show "Asyncronous error" because callback is not called. The problem is that "running" variable is increased every time getStats is called but decreased every time cb is called. If any file get filtered out then no getStats is called but cb still decreases "running".
