### PR TITLE
Callback is not called if some of the files were filtered out

### DIFF
--- a/lib/ncp.js
+++ b/lib/ncp.js
@@ -28,12 +28,12 @@ ncp.ncp = function (source, dest, options, callback) {
     if (filter) {
       if (filter instanceof RegExp) {
         if (!filter.test(item)) {
-          return cb();
+          return cb(true);
         }
       }
       else if (typeof filter === 'function') {
         if (!filter(item)) {
-          return cb();
+          return cb(true);
         }
       }
     }
@@ -181,8 +181,8 @@ ncp.ncp = function (source, dest, options, callback) {
     return cb();
   }
 
-  function cb() {
-    running--;
+  function cb(notDecreaseRunning) {
+    if (!notDecreaseRunning) running--;
     finished++;
     if ((started === finished) && (running === 0)) {
       return errs ? callback(errs) : callback(null);

--- a/test/ncp-test.js
+++ b/test/ncp-test.js
@@ -35,5 +35,44 @@ vows.describe('ncp').addBatch({
       }
     }
   }
+}).addBatch({
+  'When using ncp': {
+    'and copying files using filter': {
+      topic: function() {
+        var cb = this.callback;
+        var filter = function(name) {
+          return name.substr(name.length - 1) != 'a'
+        }
+        rimraf(out, function () {
+          ncp(src, out, {filter: filter}, cb);
+        });
+      },
+      'it should copy files': {
+        topic: function () {
+          var cb = this.callback;
+
+          readDirFiles(src, 'utf8', function (srcErr, srcFiles) {
+            function filter(files) {
+              for (var fileName in files) {
+                var curFile = files[fileName];
+                if (curFile instanceof Object)
+                  return filter(curFile);
+                if (fileName.substr(fileName.length - 1) == 'a')
+                  delete files[fileName];
+              }
+            }
+            filter(srcFiles);
+            readDirFiles(out, 'utf8', function (outErr, outFiles) {
+              cb(outErr, srcFiles, outFiles);
+            });
+          });
+        },
+        'and destination files should match source files that pass filter': function (err, srcFiles, outFiles) {
+          assert.isNull(err);
+          assert.deepEqual(srcFiles, outFiles);
+        }
+      }
+    }
+  }
 }).export(module);
 


### PR DESCRIPTION
I updated tests so you can try new tests with old code - it will show "Asyncronous error" because callback is not called. The problem is that "running" variable is increased every time getStats is called but decreased every time cb is called. If any file get filtered out then no getStats is called but cb still decreases "running".
