### PR TITLE
Fix for undefined error

### DIFF
--- a/lib/ncp.js
+++ b/lib/ncp.js
@@ -202,7 +202,9 @@ ncp.ncp = function (source, dest, options, callback) {
     if (!skipped) running--;
     finished++;
     if ((started === finished) && (running === 0)) {
-      return errs ? callback(errs) : callback(null);
+        if (callback !== undefined ) {
+            return errs ? callback(errs) : callback(null);
+        }
     }
   }
 };


### PR DESCRIPTION
When using 'fs-extra' I was getting callback is undefined error messages. This adds a check to make sure the callback is defined before calling it (basically makes the callback optional).
