### PR TITLE
Use the awesome graceful-fs module instead of nextTick

### DIFF
--- a/lib/ncp.js
+++ b/lib/ncp.js
@@ -1,4 +1,4 @@
-var fs = require('fs'),
+var fs = require('graceful-fs'),
     path = require('path');
 
 var ncp = exports;
@@ -16,10 +16,7 @@ ncp.ncp = function (source, dest, options, callback) {
       errs = null,
       started = 0,
       finished = 0,
-      running = 0,
-      limit = options.limit || ncp.limit || 16;
-
-  limit = (limit < 1) ? 1 : (limit > 512) ? 512 : limit;
+      running = 0;
 
   startCopy(currentPath);
   
@@ -41,11 +38,6 @@ ncp.ncp = function (source, dest, options, callback) {
   }
 
   function getStats(source) {
-    if (running >= limit) {
-      return process.nextTick(function () {
-        getStats(source);
-      });
-    }
     running++;
     fs.lstat(source, function (err, stats) {
       var item = {};

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "bin": {
       "ncp": "./bin/ncp"
     },
+    "dependencies": {
+        "graceful-fs": "~1.1.10"
+    },
     "devDependencies" : {
         "vows" : "0.6.x",
         "rimraf" : "1.0.x",


### PR DESCRIPTION
In Node 0.9.0 (from what I can tell) `process.nextTick` now fires before IO is complete and not after. `ncp` is using `nextTick` to throttle and with a large directory copy (350+ directories) this is failing in node 0.9.x.

Removing the throttling and adding in the use of `graceful-fs` from npm, this now works again in node 0.9.0.
