### PR TITLE
fixes #14 (unclear errors)

### DIFF
--- a/lib/ncp.js
+++ b/lib/ncp.js
@@ -195,13 +195,11 @@ function ncp (source, dest, options, callback) {
     else if (!errs) {
       errs = [];
     }
-    else if (options.errs) { 
-      if (typeof errs.write === 'undefined') {
+    if (typeof errs.write === 'undefined') {
         errs.push(err);
-      }
-      else { 
+    }
+    else { 
         errs.write(err.stack + '\n\n');
-      }
     }
     return cb();
   }


### PR DESCRIPTION
See issue #14 (unclear errors):

The error is on line 198 in ncp.js in the onError handler

This logic doesn't work properly and the options used there are undocumented. However, its clear that 

```
else if (options.errs) { 
```

wont work correctly - it means that if an errs option is not provided, no errors will ever be pushed into the errs array.

To fix this, line 198 should be simply removed, along with its closing brace. Its not necessary to check for anything there - the errs array (or stream) is already defined and errors can be pushed (or written) to it.
