### PR TITLE
Fix for node 0.10: use setImmediate()

### DIFF
--- a/lib/ncp.js
+++ b/lib/ncp.js
@@ -43,9 +43,15 @@ function ncp (source, dest, options, callback) {
     return getStats(source);
   }
 
+  function defer(fn) {
+    if (typeof(setImmediate) === 'function')
+      return setImmediate(fn);
+    return process.nextTick(fn);
+  }
+
   function getStats(source) {
     if (running >= limit) {
-      return setImmediate(function () {
+      return defer(function () {
         getStats(source);
       });
     }


### PR DESCRIPTION
In node 0.10 using recursive process.nextTick() calls breaks ('resulting in a maximum call stack size exceeded'). Use setImmediate() instead.
