### PR TITLE
Fix for hanging up when clobber=false

### DIFF
--- a/lib/ncp.js
+++ b/lib/ncp.js
@@ -85,10 +85,13 @@ function ncp (source, dest, options, callback) {
       if (writable) {
         return copyFile(file, target);
       }
-      if(clobber)
+      if(clobber) {
         rmFile(target, function () {
           copyFile(file, target);
         });
+      } else {
+        return cb();
+      }
     });
   }
 

--- a/test/ncp-test.js
+++ b/test/ncp-test.js
@@ -71,6 +71,22 @@ vows.describe('ncp').addBatch({
     }
   }
 }).addBatch({
+  'When copying files using clobber=false': {
+    topic: function(){
+      var cb = this.callback;
+
+      ncp(src, out, function(){
+        ncp(src, out, {clobber: false}, function(err){
+          cb(err);
+        })
+      })
+    },
+    'it should not hang up' : function(err) {
+      assert.isUndefined(err);
+    }
+  }
+})
+.addBatch({
    'When copying files using transform': {
       'it should pass file descriptors along to transform functions': function() {
          ncp(src, out, {


### PR DESCRIPTION
ncp hangs up if "clobber=false" and files are present in out. Test case:

```
ncp(src, out, function(){
  ncp(src, out, {clobber: false}, function(err){
    cb(err);
   })
})
```

This fixes #23
