### PR TITLE
Ensure that stats are updated when clobber = false

### DIFF
--- a/lib/ncp.js
+++ b/lib/ncp.js
@@ -85,10 +85,13 @@ function ncp (source, dest, options, callback) {
       if (writable) {
         return copyFile(file, target);
       }
-      if(clobber)
-        rmFile(target, function () {
-          copyFile(file, target);
-        });
+      if(clobber) {
+          rmFile(target, function () {
+            copyFile(file, target);
+          });
+      } else {
+          cb();
+      }
     });
   }
 


### PR DESCRIPTION
If clobber is false, the cb() callback that keeps track of the copy progress doesn't seem to ever be called. This should fix that problem. I hope this helps!
