### PR TITLE
Wait for write to finish, not read

### DIFF
--- a/lib/ncp.js
+++ b/lib/ncp.js
@@ -100,7 +100,7 @@ function ncp (source, dest, options, callback) {
     } else {
       readStream.pipe(writeStream);
     }
-    readStream.once('end', cb);
+    writeStream.once('finish', cb);
   }
 
   function rmFile(file, done) {


### PR DESCRIPTION
When copying files, wait until the write is finished before proceeding.  For network filesystems with a delay (e.g., NFS), waiting for the read to finish can cause an empty file to be created.
