### PR TITLE
Allow Dynamic File Renaming

### DIFF
--- a/lib/ncp.js
+++ b/lib/ncp.js
@@ -16,6 +16,7 @@ function ncp (source, dest, options, callback) {
       currentPath = path.resolve(basePath, source),
       targetPath = path.resolve(basePath, dest),
       filter = options.filter,
+      rename = options.rename,
       transform = options.transform,
       clobber = options.clobber !== false,
       errs = null,
@@ -84,6 +85,9 @@ function ncp (source, dest, options, callback) {
 
   function onFile(file) {
     var target = file.name.replace(currentPath, targetPath);
+    if(rename) {
+      target =  rename(target);
+    }
     isWritable(target, function (writable) {
       if (writable) {
         return copyFile(file, target);
@@ -102,7 +106,7 @@ function ncp (source, dest, options, callback) {
     var readStream = fs.createReadStream(file.name),
         writeStream = fs.createWriteStream(target, { mode: file.mode });
     if(transform) {
-      transform(readStream, writeStream,file);
+      transform(readStream, writeStream, file);
     } else {
       readStream.pipe(writeStream);
     }

--- a/test/ncp.js
+++ b/test/ncp.js
@@ -83,4 +83,25 @@ describe('ncp', function () {
       }, cb);
     });
   });
+
+  describe('when using rename', function() {
+    it('output files are correctly redirected', function(cb) {
+      ncp(src, out, {
+        rename: function(target) {
+          if(path.basename(target) == 'a') return path.resolve(path.dirname(target), 'z');
+          return target;
+        }
+      }, function(err) {
+        if(err) return cb(err);
+
+        readDirFiles(src, 'utf8', function (srcErr, srcFiles) {
+          readDirFiles(out, 'utf8', function (outErr, outFiles) {
+            assert.ifError(srcErr);
+            assert.deepEqual(srcFiles.a, outFiles.z);
+            cb();
+          });
+        });
+      })
+    })
+  })
 });


### PR DESCRIPTION
Adds support for `options.rename` which is a `function(targetPath) { return newPath; }` allowing selective renaming of files.

Not sure how useful this will be for other users, however I had need of it in one of my applications and figured I'd open a merge request in case you wanted the functionality.

**WARNING** This doesn't support renaming beyond the filename/extension, changing the directory (unless the directory already exists) is going to cause ncp to fail the copy. This isn't an issue in my use case, but it might be for others. 
