### PR TITLE
fix: open writeStream before write

### DIFF
--- a/lib/ncp.js
+++ b/lib/ncp.js
@@ -101,13 +101,16 @@ function ncp (source, dest, options, callback) {
   function copyFile(file, target) {
     var readStream = fs.createReadStream(file.name),
         writeStream = fs.createWriteStream(target, { mode: file.mode });
+    
+    readStream.on('error', onError);
+    writeStream.on('error', onError);
+    
     if(transform) {
       transform(readStream, writeStream,file);
     } else {
       writeStream.on('open', function() {
         readStream.pipe(writeStream);
       })
-      writeStream.on('error', cb);
     }
     writeStream.once(eventName, cb);
   }


### PR DESCRIPTION
If do not handle `open` event, application that use `ncp` could crash with next error

``` js
events.js:72
        throw er; // Unhandled 'error' event
              ^
Error: EACCES, open '/home/io/1.js'
```

if there it is no rights to write to file.
