### PR TITLE
Fixed linking to relative paths

### DIFF
--- a/lib/ncp.js
+++ b/lib/ncp.js
@@ -21,6 +21,7 @@ function ncp (source, dest, options, callback) {
       rename = options.rename,
       transform = options.transform,
       clobber = options.clobber !== false,
+      dereference = options.dereference,
       errs = null,
       eventName = modern ? 'finish' : 'close',
       defer = modern ? setImmediate : process.nextTick,
@@ -167,7 +168,9 @@ function ncp (source, dest, options, callback) {
   }
 
   function checkLink(resolvedPath, target) {
-    resolvedPath = path.resolve(basePath, resolvedPath);
+    if (dereference) {
+      resolvedPath = path.resolve(basePath, resolvedPath);
+    }
     isWritable(target, function (writable) {
       if (writable) {
         return makeLink(resolvedPath, target);
@@ -176,7 +179,9 @@ function ncp (source, dest, options, callback) {
         if (err) {
           return onError(err);
         }
-        targetDest = path.resolve(basePath, targetDest);
+        if (dereference) {
+          targetDest = path.resolve(basePath, targetDest);
+        }
         if (targetDest === resolvedPath) {
           return cb();
         }


### PR DESCRIPTION
In cases where the source symbolic link is pointing at a relative path and the target is at different directory level than source, the created link won't work because it's not resolved.
