### PR TITLE
followSymlink option

### DIFF
--- a/lib/ncp.js
+++ b/lib/ncp.js
@@ -21,6 +21,7 @@ function ncp (source, dest, options, callback) {
       rename = options.rename,
       transform = options.transform,
       clobber = options.clobber !== false,
+      followSymlink = options.followSymlink,
       errs = null,
       eventName = modern ? 'finish' : 'close',
       defer = modern ? setImmediate : process.nextTick,
@@ -74,8 +75,10 @@ function ncp (source, dest, options, callback) {
         return onFile(item);
       }
       else if (stats.isSymbolicLink()) {
-        // Symlinks don't really need to know about the mode.
-        return onLink(source);
+        return followSymlink ?
+          onDir(item) :
+          // Symlinks don't really need to know about the mode.
+          onLink(source);
       }
     });
   }


### PR DESCRIPTION
I added followSymlink option allowing to copy the contents of a symbolic link instead of a copying a link itself. I think this one is somehow related to [Issue #30](https://github.com/AvianFlu/ncp/issues/30).
