### PR TITLE
Make readdir ordering deterministic

### DIFF
--- a/lib/ncp.js
+++ b/lib/ncp.js
@@ -151,6 +151,7 @@ function ncp (source, dest, options, callback) {
       if (err) {
         return onError(err);
       }
+      items.sort();
       items.forEach(function (item) {
         startCopy(dir + '/' + item);
       });


### PR DESCRIPTION
The .sort is extremely fast, and it cannot hurt to make things
deterministic, to avoid flickering tests for instance.

---

This is borderline bikesheddy, but I noticed the `readdir` call without `sort` when I read the source. I like to protect all my `readdir` calls (as well as `Object.keys` and friends) with `.sort` to keep my libraries deterministic.

Please merge if you like, or close otherwise. :)
