### PR TITLE
Loosen node version check

### DIFF
--- a/lib/ncp.js
+++ b/lib/ncp.js
@@ -1,7 +1,7 @@
 var fs = require('fs'),
     path = require('path');
 
-const modern = /^v0\.1\d\.\d+$/.test(process.version);
+const modern = /^v0\.1\d\.\d+/.test(process.version);
 
 module.exports = ncp;
 ncp.ncp = ncp;


### PR DESCRIPTION
Allow pre-release builds of 0.10 and 0.11 to be treated the same as
release builds so that they are not considered "legacy".

Credit: https://github.com/AvianFlu/ncp/issues/53#issuecomment-55593112
