### PR TITLE
Fixed bugs relate to  prevent copying to itself. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 .*.sw[op]
 .DS_Store
 test/*fixtures/out
+test/*fixtures/*_out
+test/sub-directory-fixtures/src-symlink

--- a/lib/ncp.js
+++ b/lib/ncp.js
@@ -37,12 +37,33 @@ function ncp (source, dest, options, callback) {
   
   limit = (limit < 1) ? 1 : (limit > 512) ? 512 : limit;
 
-  function startsWith(target, source) {
+  function contains(target, source) {
     target = target === null ? '' : String(target);
-    return target.lastIndexOf(source, 0) === 0;
+
+    // if target exists, get the target real path.
+    if(fs.existsSync(target)){
+      target = fs.realpathSync(target);
+    }
+    source = fs.realpathSync(source);
+
+    // the target doesn't start with source path
+    var containsSource = target.lastIndexOf(source, 0) === 0 ;
+    if(!containsSource){
+      return false;
+    }
+    // get the part without source path .
+    var lastStirng = target.slice(source.length);
+
+    // target equals with source  
+    if(!lastStirng){
+      return true;
+    }
+    
+    // the target is a chlid of source if the lastString starts with path.sep.
+    return lastStirng.indexOf(path.sep) === 0;
   }
   
-  if (startsWith(targetPath, currentPath)) {
+  if (contains(targetPath, currentPath)) {
     return cback(selfCopyError);
   }
 

--- a/package.json
+++ b/package.json
@@ -1,30 +1,31 @@
 {
-    "name" : "ncp",
-    "version" : "1.0.0",
-    "author": "AvianFlu <charlie@charlieistheman.com>",
-    "description" : "Asynchronous recursive file copy utility.",
-    "bin": {
-      "ncp": "./bin/ncp"
-    },
-    "devDependencies" : {
-        "mocha": "1.15.x",
-        "rimraf" : "1.0.x",
-        "read-dir-files" : "0.0.x"
-    },
-    "main": "./lib/ncp.js",
-    "repository" : {
-        "type" : "git",
-        "url" : "https://github.com/AvianFlu/ncp.git"
-    },
-    "keywords" : [
-        "cli",
-        "copy"
-    ],
-    "license" : "MIT",
-    "engine" : {
-        "node" : ">=0.8"
-    },
-    "scripts" : {
-      "test": "mocha -R spec"
-    }
+  "name": "ncp",
+  "version": "1.0.0",
+  "author": "AvianFlu <charlie@charlieistheman.com>",
+  "description": "Asynchronous recursive file copy utility.",
+  "bin": {
+    "ncp": "./bin/ncp"
+  },
+  "devDependencies": {
+    "mkdirp": "^0.5.0",
+    "mocha": "1.15.x",
+    "read-dir-files": "0.0.x",
+    "rimraf": "1.0.x"
+  },
+  "main": "./lib/ncp.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AvianFlu/ncp.git"
+  },
+  "keywords": [
+    "cli",
+    "copy"
+  ],
+  "license": "MIT",
+  "engine": {
+    "node": ">=0.8"
+  },
+  "scripts": {
+    "test": "mocha -R spec"
+  }
 }

--- a/test/ncp.js
+++ b/test/ncp.js
@@ -211,9 +211,9 @@ describe('ncp', function () {
         rimraf(src_out, function(e) {
           fs.mkdirSync(src_out);
           rimraf(double_src_before_out, function() {
-            mkdirp(double_src_before_out);
+            mkdirp.sync(double_src_before_out);
             rimraf(double_src_middle_out, function() {
-              mkdirp(double_src_middle_out);
+              mkdirp.sync(double_src_middle_out);
               if (fs.existsSync(src_symlink)) {
                 fs.unlink(src_symlink, cb);
               } else {


### PR DESCRIPTION
I try to fix the issue #60,  If I missed something , please let me know.

This PR  refactoring the `startsWith` function and try to handle more situations. I  add more testcases to test the different situations. ** Some testcases can't used in Windows** :

  1. **Copy to  sub-folder**
     1. `src`  to `src`/out
  2. **Copy to itself**
      1. `src` to `src`
  3. **Copy to the folder starts with `src`**
      1. `src` to `src_out`
  4. **Copy to the symlink folder** 
      1.  `src` to `src-symlink`
  5. **Copy the file to itself** 
      1. `src`/a to `src`/a
  6.  **More complex situations**: 
     1. `src` to `src`/`src`_out
     2. `src` to `src`_out/`src` 

And I add mkdirp to devDependencies  to create the directory easily.

