### PR TITLE
fix onFile: removed cb call that have no sense

### DIFF
--- a/lib/ncp.js
+++ b/lib/ncp.js
@@ -94,13 +94,11 @@ function ncp (source, dest, options, callback) {
     isWritable(target, function (writable) {
       if (writable) {
         return copyFile(file, target);
-      }
-      if(clobber) {
+      } else if(clobber) {
         rmFile(target, function () {
           copyFile(file, target);
         });
-      }
-      if (modified) {
+      } else if (modified) {
         var stat = dereference ? fs.stat : fs.lstat;
         stat(target, function(err, stats) {
             //if souce modified time greater to target modified time copy file
@@ -108,9 +106,8 @@ function ncp (source, dest, options, callback) {
                 copyFile(file, target);
             else return cb();
         });
-      }
-      else {
-        return cb();
+      } else {
+          cb();
       }
     });
   }


### PR DESCRIPTION
In function `onFile` if `!modified` callback called. `modified` is not declared in `README.md`.
If we have a lot files (100, for example) because of this call `running` and `finished` has wrong values so:
1. Callback could not be called (this could be never true `if ((started === finished) && (running === 0)`)
2. Callback could be called earlier then it should.

`modified` flag should be added to `README.md` I think or be deleted, because nobody knows about it.
