### PR TITLE
Switch package to use mkdirp so that files can be copied into a ...

### DIFF
--- a/lib/ncp.js
+++ b/lib/ncp.js
@@ -1,5 +1,6 @@
 var fs = require('fs'),
-    path = require('path');
+    path = require('path'),
+    mkdirp = require('mkdirp');
 
 const modern = /^v0\.1\d\.\d+/.test(process.version);
 
@@ -158,7 +159,7 @@ function ncp (source, dest, options, callback) {
   }
 
   function mkDir(dir, target) {
-    fs.mkdir(target, dir.mode, function (err) {
+    mkdirp(target, dir.mode, function (err) {
       if (err) {
         return onError(err);
       }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
       "ncp": "./bin/ncp"
     },
     "devDependencies" : {
+        "mkdirp": "0.5.x",
         "mocha": "1.15.x",
         "rimraf" : "1.0.x",
         "read-dir-files" : "0.0.x"

--- a/test/ncp.js
+++ b/test/ncp.js
@@ -194,4 +194,26 @@ describe('ncp', function () {
       });
 
   });
+
+  describe('copies into folder missing parent', function() {
+      var fixtures = path.join(__dirname, 'regular-fixtures'),
+          src = path.join(fixtures, 'src'),
+          out = path.join(fixtures, 'dne/dne');
+          outParent = path.join(fixtures, 'dne');
+
+      before(function (cb) {
+        rimraf(outParent, function() {
+          ncp(src, out, cb);
+        });
+      });
+      it('files are copied correctly', function (cb) {
+        readDirFiles(src, 'utf8', function (srcErr, srcFiles) {
+          readDirFiles(out, 'utf8', function (outErr, outFiles) {
+            assert.ifError(srcErr);
+            assert.deepEqual(srcFiles, outFiles);
+            cb();
+          });
+        });
+      });
+  });
 });


### PR DESCRIPTION
... new folder deeper than the current, with missing intermediate folders.