### PR TITLE
Fix multiple calls to callback when overwriting files

### DIFF
--- a/lib/ncp.js
+++ b/lib/ncp.js
@@ -99,7 +99,7 @@ function ncp (source, dest, options, callback) {
           copyFile(file, target);
         });
       }
-      if (modified) {
+      else if (modified) {
         var stat = dereference ? fs.stat : fs.lstat;
         stat(target, function(err, stats) {
             //if souce modified time greater to target modified time copy file
@@ -254,6 +254,15 @@ function ncp (source, dest, options, callback) {
   function cb(skipped) {
     if (!skipped) running--;
     finished++;
+    if(running < 0 || finished > started) {
+      if(cback !== undefined) {
+        var err = new Error("Invalid state", "INVALID_STATE");
+        err.running = running;
+        err.finished = finished;
+        err.started = started;
+        return cback(err);
+      }
+    }
     if ((started === finished) && (running === 0)) {
       if (cback !== undefined ) {
         return errs ? cback(errs) : cback(null);

--- a/test/ncp.js
+++ b/test/ncp.js
@@ -110,6 +110,30 @@ describe('ncp', function () {
     });
   });
 
+  describe('callbacks sanity checks', function() {
+      "use strict";
+      describe('regular files and directories', function () {
+          var fixtures = path.join(__dirname, 'regular-fixtures'),
+              src = path.join(fixtures, 'src'),
+              out = path.join(fixtures, 'out');
+
+          before(function (cb) {
+              rimraf(out, function () {
+                  ncp(src, out, cb);
+              });
+          });
+
+          describe('when overwriting files', function () {
+              it('should call the callback only once', function (cb) {
+                  ncp(path.join(src,"c"), path.join(out, "c"), {}, function (err) {
+                      cb(err);
+                  });
+              });
+          });
+
+      });
+  });
+
   describe('symlink handling', function () {
     var fixtures = path.join(__dirname, 'symlink-fixtures'),
         src = path.join(fixtures, 'src'),


### PR DESCRIPTION
The logic when overwriting a file seems wrong. If you look at the code path, if clobber is true and modified is false, then there will be a systematic call to cb in the last else statement of onFile.

I've seen the bug in an app of mine that uses ncp but it was hard to trigger and all your unit tests passed.
So I added an additional sanity check in the cb handler that verifies that running is postive or zero and that finished is lower or equal to started.
After doing that, your tests would nearly all fails because of multiple calls to done => which means that one of those invalid situations happened while with the fix in inFile it does work.