### PR TITLE
Support io.js 1.0

### DIFF
--- a/lib/ncp.js
+++ b/lib/ncp.js
@@ -1,7 +1,8 @@
 var fs = require('fs'),
     path = require('path');
 
-const modern = /^v0\.1\d\.\d+/.test(process.version);
+const modern = /^v0\.1\d\.\d+/.test(process.version) // node.js 0.10+
+  || /^v1\.\d+\.\d+/.test(process.version); // io.js 1.0
 
 module.exports = ncp;
 ncp.ncp = ncp;


### PR DESCRIPTION
Fix the condition used to check whether streams are modern, correctly detect io.js 1.0 as a modern engine.

This fixes the install script used by [phantomjs](https://github.com/Medium/phantomjs) which hangs inside `ncp` at the moment.

I was not able to reproduce the problem locally inside ncp, thus there is no test to cover this change :(

@mmalecki @AvianFlu Could you please review, land and release this patch as soon as reasonably possible? `ncp` is used e.g. by Karma test runner (karma-phantomjs-launcher), thus most front-end people cannot upgrade to io.js until this fix is landed.