### PR TITLE
Document options.rename in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ You can also call ncp like `ncp(source, destination, options, callback)`.
   parameter: copied file name, returning `true` or `false`, determining
   whether to copy file or not.
 
+  * `options.rename` - a function: `function (destPath) { return destPath }`
+  used to rename the destination file name
+
   * `options.transform` - a function: `function (read, write) { read.pipe(write) }`
   used to apply streaming transforms while copying.
 


### PR DESCRIPTION
`options.rename` is supported -- mention it in the README.

(this is a feature I was looking for in ncp - was glad to have found it in the code)
