### PR TITLE
Fix early callback and possible duplicate copies when clobbering files

### DIFF
--- a/lib/ncp.js
+++ b/lib/ncp.js
@@ -91,7 +91,7 @@ function ncp (source, dest, options, callback) {
         return copyFile(file, target);
       }
       if(clobber) {
-        rmFile(target, function () {
+        return rmFile(target, function () {
           copyFile(file, target);
         });
       }

--- a/test/ncp.js
+++ b/test/ncp.js
@@ -65,6 +65,26 @@ describe('ncp', function () {
       });
     });
 
+    describe('when using clobber=true', function () {
+      before(function () {
+        this.originalCreateReadStream = fs.createReadStream;
+      });
+
+      after(function () {
+        fs.createReadStream = this.originalCreateReadStream;
+      });
+
+      it('the copy is complete after callback', function (cb) {
+        ncp(src, out, {clobber: true}, function(err) {
+          fs.createReadStream = function() {
+            cb(new Error('createReadStream after callback'));
+          };
+          assert.ifError(err);
+          process.nextTick(cb);
+        });
+      });
+    });
+
     describe('when using clobber=false', function () {
       it('the copy is completed successfully', function (cb) {
         ncp(src, out, function() {


### PR DESCRIPTION
One-line fix for issue #71 and others documenting the same problem. Please feel free to take the fix without the test if `fs` function swizzling is not your thing.
