### PR TITLE
this change addresses issue #74 - Filter, submitted by CSester.

### DIFF
--- a/lib/ncp.js
+++ b/lib/ncp.js
@@ -33,7 +33,7 @@ function ncp (source, dest, options, callback) {
   
   function startCopy(source) {
     started++;
-    if (filter) {
+    if (filter && started > 1) {
       if (filter instanceof RegExp) {
         if (!filter.test(source)) {
           return cb(true);


### PR DESCRIPTION
the cause: when a regex filter is provided as an option, the first
check is made against the path name, and if the path does not match the
regex option, then the callback function is called with no error, and
the code is exited without processing any of the files within the
folder.
this change simply ignores the first iteration through the startCopy
function, which is the path name.
