### PR TITLE
Fixed overwrite while copying large number of files

### DIFF
--- a/lib/ncp.js
+++ b/lib/ncp.js
@@ -91,7 +91,7 @@ function ncp (source, dest, options, callback) {
         return copyFile(file, target);
       }
       if(clobber) {
-        rmFile(target, function () {
+        return rmFile(target, function () {
           copyFile(file, target);
         });
       }


### PR DESCRIPTION
Try copy and overwriting 200+ files from one directory to another directory where all those files already exist. You will notice that the node process will be completed but files were not copied.